### PR TITLE
migrate config to services JSON, bump to v2.0.4-alpha1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .cxx
 local.properties
 logdrop-services.json
+app/google-services.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+logdrop-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,6 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "LOGDROP_API_KEY", "\"YOUR_API_KEY\"")
-        buildConfigField("String", "LOGDROP_BASE_URL", "\"YOUR_BASE_URL\"")
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.google.services)
 
     id("io.logdrop.gradle.plugin")
 }
@@ -45,6 +46,9 @@ android {
 dependencies {
 
     implementation (libs.logdropsdk)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaging)
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,14 @@
             android:exported="true"
             android:theme="@style/Theme.LogDropAndroidDemoApp">
         </activity>
+
+        <service
+            android:name=".notifications.AppMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/io/initialcode/logdropandroiddemoapp/LogDropAndroidDemoApp.kt
+++ b/app/src/main/java/io/initialcode/logdropandroiddemoapp/LogDropAndroidDemoApp.kt
@@ -3,16 +3,47 @@ package io.initialcode.logdropandroiddemoapp
 import android.app.Application
 import io.logdrop.sdk.LogDrop
 import io.logdrop.sdk.LogDropConfig
+import org.json.JSONObject
 
 class LogDropAndroidDemoApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
 
-        val config = LogDropConfig.Builder()
-            .logcatEnabled(true)
-            .build()
+        // Register activity lifecycle callbacks for session/push tracking
+        LogDrop.registerActivityLifecycleCallback(this)
 
-        LogDrop.init(this, config)
+        val configBuilder = LogDropConfig.Builder()
+            .logcatEnabled(true)
+
+        val configData = loadLogDropConfig()
+        if (configData != null) {
+            val (appId, baseUrl) = configData
+            if (baseUrl.isNotEmpty()) {
+                configBuilder.baseUrl(baseUrl)
+            }
+            configBuilder.appId(appId)
+        }
+
+        LogDrop.init(this, configBuilder.build())
+    }
+
+    private fun loadLogDropConfig(): Pair<String, String>? {
+        return try {
+            val jsonString = assets.open("logdrop-services.json").bufferedReader().use { it.readText() }
+            val jsonObject = JSONObject(jsonString)
+            val baseUrl = jsonObject.optString("base_url", "")
+            val projects = jsonObject.optJSONObject("projects")
+            val project = projects?.optJSONObject(packageName)
+            val appId = project?.optString("app_id", "") ?: project?.optString("api_key", "") ?: ""
+            if (appId.isNotEmpty()) {
+                Pair(appId, baseUrl)
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
     }
 }

--- a/app/src/main/java/io/initialcode/logdropandroiddemoapp/LogDropAndroidDemoApp.kt
+++ b/app/src/main/java/io/initialcode/logdropandroiddemoapp/LogDropAndroidDemoApp.kt
@@ -10,17 +10,7 @@ class LogDropAndroidDemoApp : Application() {
         super.onCreate()
 
         val config = LogDropConfig.Builder()
-            .apiKey(BuildConfig.LOGDROP_API_KEY)
-            .baseUrl(BuildConfig.LOGDROP_BASE_URL)
             .logcatEnabled(true)
-            .crashTrackingEnabled(true)
-            .sensitiveInfoFilter(
-                listOf(
-                    Regex("^cardNo:\\s(?:\\d{4}[-\\s]?){3}\\d{4}$"),
-                    Regex("password=[^&\\s]+")
-                )
-            )
-            .crashTrackingEnabled(true)
             .build()
 
         LogDrop.init(this, config)

--- a/app/src/main/java/io/initialcode/logdropandroiddemoapp/notifications/AppMessagingService.kt
+++ b/app/src/main/java/io/initialcode/logdropandroiddemoapp/notifications/AppMessagingService.kt
@@ -1,0 +1,23 @@
+package io.initialcode.logdropandroiddemoapp.notifications
+
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import io.logdrop.sdk.LogDrop
+
+class AppMessagingService : FirebaseMessagingService() {
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        if (LogDrop.isLogDropPush(remoteMessage.data)) {
+            LogDrop.onRemoteMessageReceived(
+                context = this,
+                data = remoteMessage.data,
+                notificationTitle = remoteMessage.notification?.title,
+                notificationBody = remoteMessage.notification?.body
+            )
+        }
+    }
+
+    override fun onNewToken(token: String) {
+        LogDrop.onNewFcmPushToken(token)
+    }
+}

--- a/app/src/main/java/io/initialcode/logdropandroiddemoapp/utils/DummyData.kt
+++ b/app/src/main/java/io/initialcode/logdropandroiddemoapp/utils/DummyData.kt
@@ -12,7 +12,7 @@ object DummyData {
 
     const val failedApiResponse = """
     --- REQUEST ---------------------------------
-    POST https://api.logdrop.dev/v1/account/manage
+    POST https://cashapp-demo.logdrop.io/v1/account/manage
     Headers:
         Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
         Content-Type: application/json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.google.services) apply false
 }
 buildscript {
     repositories {
@@ -11,6 +12,6 @@ buildscript {
         maven { url = uri("https://artifactory.logdrop.io/repository/logdrop-gradle-plugin/") }
     }
     dependencies {
-        classpath("io.logdrop.gradle:plugin:1.0.8-alpha1")
+        classpath("io.logdrop.gradle:plugin:1.1.0")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,6 @@ buildscript {
         maven { url = uri("https://artifactory.logdrop.io/repository/logdrop-gradle-plugin/") }
     }
     dependencies {
-        classpath("io.logdrop.gradle:plugin:1.0.0")
+        classpath("io.logdrop.gradle:plugin:1.0.8-alpha1")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
-logdropsdk = "1.0.1"
+logdropsdk = "2.0.4-alpha1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,9 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
-logdropsdk = "2.0.4-alpha1"
+logdropsdk = "2.0.6"
+firebaseBom = "33.1.2"
+googleServices = "4.4.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -26,9 +28,12 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 logdropsdk = { module = "io.logdrop:sdk", version.ref = "logdropsdk" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://artifactory.logdrop.io/repository/android-logdrop-sdk/") }
+        maven { url = uri("https://dev-nexus.logdrop.io/repository/dev-logdrop-sdk/") }
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,6 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven { url = uri("https://artifactory.logdrop.io/repository/android-logdrop-sdk/") }
-        maven { url = uri("https://dev-nexus.logdrop.io/repository/dev-logdrop-sdk/") }
     }
 }
 


### PR DESCRIPTION
- Replace BuildConfig API key/URL fields with logdrop-services.json
- Ignore logdrop-services.json to keep credentials out of repo
- Plugin 1.0.0 → 1.0.8-alpha1
- SDK 1.0.1 → 2.0.4-alpha1
- Add dev Nexus repo for alpha artifacts